### PR TITLE
Add Play Next Song and Play Previous Song functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,11 @@ Displays the currently playing song in Spotify in Atom's status bar.
 
 ![](https://dl.dropbox.com/s/5grx2ol4g4lcvb0/Screenshot%202014-02-28%2021.40.14.png)
 
+Use the following key commands to control Spotify from inside Atom:
+
+- **Play next song**: `cmd-shift-right`
+- **Play previous song**: `cmd-shift-left`
+
+Or use the menu items in *Packages -> Spotify*.
+
 Pull requests welcome (and encouraged!)

--- a/keymaps/atom-spotify.cson
+++ b/keymaps/atom-spotify.cson
@@ -1,0 +1,3 @@
+'.platform-darwin, .platform-darwin .command-palette .editor':
+  'cmd-shift-right': 'atom-spotify:next'
+  'cmd-shift-left': 'atom-spotify:previous'

--- a/lib/atom-spotify-status-bar-view.coffee
+++ b/lib/atom-spotify-status-bar-view.coffee
@@ -8,6 +8,9 @@ class AtomSpotifyStatusBarView extends View
       @span outlet: "trackInfo", class: 'atom-spotify-status', tabindex: '-1', ""
 
   initialize: ->
+    atom.workspaceView.command 'atom-spotify:next', => spotify.next => @updateTrackInfo()
+    atom.workspaceView.command 'atom-spotify:previous', => spotify.previous => @updateTrackInfo()
+
     # We wait until all the other packages have been loaded,
     # so all the other status bar views have been attached
     @subscribe atom.packages.once 'activated', =>
@@ -18,8 +21,11 @@ class AtomSpotifyStatusBarView extends View
         atom.workspaceView.statusBar.appendLeft(this)
       , 1
 
+  updateTrackInfo: ->
+    spotify.getTrack (error, track) =>
+      @trackInfo.text("♫ #{track.artist} - #{track.name}") if track
+
   afterAttach: ->
     setInterval =>
-      spotify.getTrack (error, track) =>
-        @trackInfo.text("♫ #{track.artist} - #{track.name}")
+      @updateTrackInfo()
     , 1000

--- a/menus/atom-spotify.cson
+++ b/menus/atom-spotify.cson
@@ -1,0 +1,12 @@
+'menu': [
+  {
+    'label': 'Packages'
+    'submenu': [
+      'label': 'Spotify'
+      'submenu': [
+        { 'label': 'Play next song', 'command': 'atom-spotify:next' }
+        { 'label': 'Play previous song', 'command': 'atom-spotify:previous' }
+      ]
+    ]
+  }
+]


### PR DESCRIPTION
- Use `cmd-shift-right` to play the next song
- Use `cmd-shift-left` to play the previous song
- Both commands can also be accessed via _Packages -> Spotify_ in the menu
- Fix an error when `spotify.getTrack` couldn't retrieve the current track
