### PR TITLE
Added play/pause display.

### DIFF
--- a/lib/atom-spotify-status-bar-view.coffee
+++ b/lib/atom-spotify-status-bar-view.coffee
@@ -62,17 +62,28 @@ class AtomSpotifyStatusBarView extends View
   updateTrackInfo: () ->
     spotify.isRunning (err, isRunning) =>
       if isRunning
-        spotify.getTrack (error, track) =>
-          if track
-            trackInfoText = "#{track.artist} - #{track.name}"
+        spotify.getState (err, state)=>
+          if state
+            spotify.getTrack (error, track) =>
+              if track
+                trackInfoText = ""
+                if atom.config.get('atom-spotify.showPlayStatus')
+                  if !atom.config.get('atom-spotify.showPlayIconAsText')
+                    trackInfoText = if state.state == 'playing' then '► ' else '|| '
+                  else
+                    trackInfoText = if state.state == 'playing' then 'Now Playing: ' else 'Paused: '
+                trackInfoText += "#{track.artist} - #{track.name}"
 
-            if !atom.config.get('atom-spotify.showEqualizer')
-              trackInfoText = "♫ " + trackInfoText
+                if !atom.config.get('atom-spotify.showEqualizer')
+                  if atom.config.get('atom-spotify.showPlayStatus')
+                    trackInfoText += " ♫"
+                  else
+                    trackInfoText = "♫ " + trackInfoText
 
-            @trackInfo.text trackInfoText
-          else
-            @trackInfo.text('')
-          @updateEqualizer()
+                @trackInfo.text trackInfoText
+              else
+                @trackInfo.text('')
+              @updateEqualizer()
       else # spotify isn't running, hide the sound bars!
         @trackInfo.text('')
 

--- a/lib/atom-spotify.coffee
+++ b/lib/atom-spotify.coffee
@@ -5,6 +5,8 @@ module.exports =
   configDefaults:
     displayOnLeftSide: true
     showEqualizer: false
+    showPlayStatus: true;
+    showPlayIconAsText: false;
 
   activate: ->
     @atomSpotifyStatusBarView = new AtomSpotifyStatusBarView()


### PR DESCRIPTION
Adds configuration necessary for configuring whether or not to display the
play state and as icon/text.
Also uses unicode right-pointing triangle for play, two pipe '|' characters
for pause.

Related to this issue by me: https://github.com/jakemarsh/atom-spotify/issues/11
